### PR TITLE
📦 Se corrigió un bug del header

### DIFF
--- a/src/components/molecules/Header/_header.scss
+++ b/src/components/molecules/Header/_header.scss
@@ -7,7 +7,7 @@
   width: 100%;
   position: fixed;
   padding: 0 2rem;
-  z-index: 100;
+  z-index: 1000;
   &__container {
     backdrop-filter: blur(20px);
     @include centerFlex(space-between);


### PR DESCRIPTION
Solo cambie el z-index ya que un elemento se sobrepone del header por lo que nada mas agregue un 0 para que quedara como z-index: 1000

![{8E69D05F-8E91-410A-8EB7-AE9AC7E57291}](https://github.com/user-attachments/assets/7b1da815-edbd-4dca-8c35-ed8bea1d41e3)
