### PR TITLE
Se cambio el output de server a hybrid para usar prerender por defecto.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,6 @@ import vercelServerless from "@astrojs/vercel/serverless";
 export default defineConfig({
   site: "https://itssofi.dev",
   integrations: [react()],
-  output: "server",
+  output: "hybrid",
   adapter: vercelServerless(),
 });

--- a/src/components/organisms/Hero/Hero.astro
+++ b/src/components/organisms/Hero/Hero.astro
@@ -2,7 +2,6 @@
 import BackgroundIconsFloat from "@src/components/atoms/BackgroundIconsFloat/BackgroundIconsFloat.astro";
 import ProfilePicture from "@src/components/atoms/ProfilePicture/ProfilePicture.astro";
 import SocialIcons from "@src/components/atoms/SocialIcons/SocialIcons.astro";
-export const prerender = true;
 const { data } = Astro.props
 ---
 

--- a/src/controllers/shuffleSkills.controller.js
+++ b/src/controllers/shuffleSkills.controller.js
@@ -1,6 +1,4 @@
 import { getData } from "@src/services/data"
-export const prerender = true;
-
 const skillsData = await getData( "skills",  true);
 
 /* Shuffle initial function */

--- a/src/pages/api/[dataType].ts
+++ b/src/pages/api/[dataType].ts
@@ -9,6 +9,8 @@ import { socialIconsData } from "@src/data/socialIconsData";
 import { userData } from "@src/data/userData";
 import { toolsData } from "@src/data/ToolsData";
 
+export const prerender = false;
+
 // Creamos un objeto 'dataTypes' que mapea los nombres de los tipos de datos a sus respectivos valores.
 // Este objeto permite acceder rápidamente a los datos según el tipo solicitado.
 const dataTypes = {

--- a/src/pages/api/email-sender.ts
+++ b/src/pages/api/email-sender.ts
@@ -2,6 +2,7 @@
 // También importamos la función 'sendEmail', que se encargará de enviar el correo electrónico.
 import type { APIRoute } from "astro";
 import { sendEmail } from "@src/services/mailer";
+export const prerender = false;
 
 // Definimos un objeto 'ERROR' que contiene mensajes de error comunes.
 // Esto nos permite reutilizar mensajes de error en todo el código para una mejor organización.

--- a/src/pages/builtwith.json.js
+++ b/src/pages/builtwith.json.js
@@ -1,4 +1,6 @@
 // Salidas: /builtwith.json
+export const prerender = false;
+
 export async function GET({params, request}) {
     return new Response(
       JSON.stringify({

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,6 @@ import Social from "@src/components/organisms/Social/Social.astro";
 import Footer from "@molecules/Footer/Footer.astro";
 import { getData } from "@src/services/data";
 import ToastNotification from "@src/components/atoms/ToastNotification/ToastNotification.astro";
-export const prerender = true;
 const { user, skills, tools, socialIcons } = await getData();
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import Social from "@src/components/organisms/Social/Social.astro";
 import Footer from "@molecules/Footer/Footer.astro";
 import { getData } from "@src/services/data";
 import ToastNotification from "@src/components/atoms/ToastNotification/ToastNotification.astro";
+export const prerender = true;
 const { user, skills, tools, socialIcons } = await getData();
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import Social from "@src/components/organisms/Social/Social.astro";
 import Footer from "@molecules/Footer/Footer.astro";
 import { getData } from "@src/services/data";
 import ToastNotification from "@src/components/atoms/ToastNotification/ToastNotification.astro";
-const { user, skills, tools, socialIcons } = await getData();
+const { user, skills, tools } = await getData();
 ---
 
 <script>
@@ -21,7 +21,7 @@ const { user, skills, tools, socialIcons } = await getData();
 <Layout>
   <ToastNotification />
   <BackgroundGradient>
-    <Hero data={user} socialIcons={socialIcons} />
+    <Hero data={user} />
   </BackgroundGradient>
   <DividerTop />
   <About data={user} />


### PR DESCRIPTION
Para no estar agregando prerender manualmente a las paginas, se cambio el modo server a hybrid que por defecto todo se prerenderiza excepto las paginas y endpoints a las cuales se le indique un prerender falso.

Se desactivo el prerender para los endpoints (/api) para que sigan funcionando en modo SSR;
- email-sender 
- [dataType]
 